### PR TITLE
Remove floating Nav bar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
 
 <body id="page-top">
 
-    <nav id="mainNav" class="navbar navbar-default">
+    <nav class="navbar navbar-default">
         <div class="container-fluid">
             <!-- Brand and toggle get grouped for better mobile display -->
             <!--TODO PES the header is not behaving on iPad.  We don't need it to be fixed -->


### PR DESCRIPTION
Public nav was broken on scroll because of [Creative bootstrap theme](https://startbootstrap.com/template-overviews/creative/).
This theme runs javascript code expecting `.navbar-fixed-top` class which was removed from 4c1b1bc5d60bd12c1a9853b3b6b9de6b82ec5bd8.

I have disabled this theme to the public nav to fix the issue. If the top fixed nav is not needed, the javascript part of this theme could be deleted.

The theme related files:
app/assets/javascripts/creative.js
app/assets/stylesheets/creative.css.scss
