### PR TITLE
Rollback min password length to 4

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   acts_as_authentic do |config|
+    config.validates_length_of_password_field_options = { minimum: 4 }
     config.crypto_provider = Authlogic::CryptoProviders::BCrypt
   end
 


### PR DESCRIPTION
Authlogic v3.5 increased the min password length from 4 to 8.
This breaks tests and seeding.

If the min password length does not need to be 8 then I suggest to keep 4 as before.

References:
https://github.com/binarylogic/authlogic/blob/master/CHANGELOG.md