### PR TITLE
Fix `shipped?` filter (No) cancels `Further contact?` filter

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -27,7 +27,7 @@ class Customer < ActiveRecord::Base
     where(territorial_authority_id: ids)
   }
   scope :can_ship_to, -> {
-    where(further_contact_requested:
+    where("further_contact_requested in (?)",
             [self.further_contact_requesteds[:not_specified],
              self.further_contact_requesteds[:wanted]]).
       where(bad_address: false)


### PR DESCRIPTION
Example: `shipped?` (No) and `Further contact?` (2: wanted)

This generates queries including below
```ruby
Order.joins(:customer).merge(Customer.where(further_contact_requested: 2)).
                       merge(Customer.where(further_contact_requested: [0, 2]))
```

The expected result is to join both query using `and` like below
```ruby
Order.joins(:customer).merge(Customer.where(further_contact_requested: 2).
                                      where(further_contact_requested: [0, 2]))
```

But in this special case (merge a key value pair query to the same field in a joined model)
Rails overrides the old query to the new one like below.
```ruby
Order.joins(:customer).merge(Customer.where(further_contact_requested: [0, 2]))
```

I fixed the issue by converting one of them to a raw where clause.