### PR TITLE
Rollback missing password validation condition

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   acts_as_authentic do |config|
-    config.validates_length_of_password_field_options = { minimum: 4 }
+    config.validates_length_of_password_field_options =
+      { :minimum => 4, :if => :require_password? }
     config.crypto_provider = Authlogic::CryptoProviders::BCrypt
   end
 


### PR DESCRIPTION
Password param is required to update user records after https://github.com/BFNZ/bfnz/pull/2

Problem:

validates_length_of_password_field_options's default is
{:minimum => 8, :if => :require_password?} and {:if => :require_password?}
is removed from the pull request.

I should have checked the default options.