### PR TITLE
Revert changing to https for svg xmlns=

### DIFF
--- a/app/assets/images/glyphicons-halflings-regular.svg
+++ b/app/assets/images/glyphicons-halflings-regular.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="https://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
 <font id="glyphicons_halflingsregular" horiz-adv-x="1200" >

--- a/public/font-awesome/fonts/fontawesome-webfont.svg
+++ b/public/font-awesome/fonts/fontawesome-webfont.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" version="1.1">
 <metadata></metadata>
 <defs>
 <font id="fontawesomeregular" horiz-adv-x="1536" >

--- a/public/fonts/glyphicons-halflings-regular.svg
+++ b/public/fonts/glyphicons-halflings-regular.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="https://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
 <font id="glyphicons_halflingsregular" horiz-adv-x="1200" >

--- a/public/img/bfnz.svg
+++ b/public/img/bfnz.svg
@@ -6,7 +6,7 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="https://www.w3.org/2000/svg"
-   xmlns="https://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"


### PR DESCRIPTION
Found one problem from the previous merge.

It seems that browsers fail to load svg if xmlns url is https.
https://stackoverflow.com/questions/39573020/requested-https-www-w3-org-2000-svg-found-http-www-w3-org-2000-svg