### PR TITLE
Sort item codes

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -39,6 +39,6 @@ class Order < ActiveRecord::Base
   end
 
   def item_codes
-    items.map(&:code).join
+    items.map(&:code).sort.join
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -42,6 +42,21 @@ describe Order do
     end
   end
 
+  describe ".item_codes" do
+    subject(:item_ids_scope) { Order.item_ids([new_testament.id]) }
+
+    let(:new_testament) { Item.find_by_code('R') }
+    let(:church) { Item.find_by_code('C') }
+
+    let!(:order_1) { Order.make!(items: [new_testament, church]) }
+    let!(:order_2) { Order.make!(items: [church, new_testament]) }
+
+    it "returns codes of items sorted" do
+      expect(order_1.item_codes).to eq('CR')
+      expect(order_2.item_codes).to eq('CR')
+    end
+  end
+
   describe ".shipped" do
     subject(:shipped_scope) { Order.shipped }
 


### PR DESCRIPTION
Sort item codes so that RTEC-90888 and TREC-90888 becomes CERT-90888.

order.item_codes.chars.sort.join to /admin/labels/index_view.rb works for the page but csv uses `order_code` from app/presenters/admin/label_csv_presenter.rb

Sorted order.item_codes directly so both page and csv show the sorted item codes 