### PR TITLE
Fix page-scroll class bug to none anchor links

### DIFF
--- a/app/assets/javascripts/creative.js
+++ b/app/assets/javascripts/creative.js
@@ -8,7 +8,7 @@
     "use strict"; // Start of use strict
 
     // jQuery for page scrolling feature - requires jQuery Easing plugin
-    $('a.page-scroll').bind('click', function(event) {
+    $('a[href^="#"]').bind('click', function(event) {
         var $anchor = $(this);
         $('html, body').stop().animate({
             scrollTop: ($($anchor.attr('href')).offset().top - 50)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,8 +11,8 @@
                <br>
                 <h1>Know God and <br>understand the Bible <br>in a deeper way</h1>
                 <h2>We give away free study Bibles and Christian books that help you progress in your Christian life. </h2>
-                <%= link_to 'Order yours now', new_order_path, class: 'btn btn-primary btn-xl page-scroll' %>
-                <a class="btn btn-primary btn-xl page-scroll" href="/#freebooks">Learn more about our Free Books</a>
+                <%= link_to 'Order yours now', new_order_path, class: 'btn btn-primary btn-xl' %>
+                <a class="btn btn-primary btn-xl" href="#freebooks">Learn more about our Free Books</a>
             </div>
         </div>
 
@@ -64,7 +64,7 @@
                         <a href="/staticpages/Sample/#recovery"><img src="/img/rcv.jpg" style="padding-top:20px;padding-bottom:20px;"></a>
                         <p class="text-muted">The <i>New Testament Recovery Version</i> is a comprehensive study Bible accurately translated from the original Greek text into modern English. It features extensive notes emphasizing the revelation of the truth, outlines of each book, cross-references, charts and maps, and more. <a href="/staticpages/Sample/#recovery">Learn more</a></p>
                         <br><br>
-                        <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl page-scroll bfnzposition' %>
+                        <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl bfnzposition' %>
                         <br><br><br>
                     </div>
                 </div>
@@ -76,7 +76,7 @@
                         <a href="/staticpages/Books/#foundation"><img src="/img/basic_elements_large.jpg" style="padding-top:20px;padding-bottom:20px;"></a>
                         <p class="text-muted"><i>Basic Elements of the Christian Life</i>, vols. 1-3 details the basic yet crucial elements of truth and practice for the Christian life. <a href="/staticpages/Books/#foundation">Learn more</a></p>
                         <br><br>
-                        <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl page-scroll bfnzposition' %>
+                        <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl bfnzposition' %>
                         <br><br><br>
                     </div>
                 </div>
@@ -88,7 +88,7 @@
                       <a href="/staticpages/Books/#christian"><img src="/img/christian_experience.jpg" style="padding-top:20px;padding-bottom:20px;"></a>
                       <p class="text-muted"><i>The Normal Christian Life</i>, and <i>The Economy of God</i> will broaden your understanding of what it means to be a Christian and lead you into a deeper walk with Christ. <a href="/staticpages/Books/#christian">Learn more</a></p>
                       <br><br>
-                      <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl page-scroll bfnzposition' %>
+                      <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl bfnzposition' %>
                       <br><br><br>
                    </div>
                 </div>
@@ -100,7 +100,7 @@
                         <a href="/staticpages/Books/#church"><img src="/img/church_set.jpg" style="padding-top:20px;padding-bottom:20px;"></a>
                         <p class="text-muted"><i>The All-Inclusive Christ</i> explains and applies the riches of the good land to our experience of Christ today. <i>The Glorious Church</i> uses types of the church in the Bible to show us the church's origin, purpose, and destiny. <a href="/staticpages/Books/#church">Learn more</a></p>
                         <br><br>
-                        <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl page-scroll bfnzposition' %>
+                        <%= link_to 'Order Free here', new_order_path, class: 'btn btn-primary btn-xl bfnzposition' %>
                         <br><br><br>
                     </div>
                 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,12 +65,12 @@
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">
-                    <li><a class="page-scroll" href="/orders/new"><h3>Order</h3> <i>Bibles and books</i></a>
-                     <li><a class="page-scroll" href="/staticpages/Gospel/#gospel"> <h3>Share</h3><i>The Gospel </i></a>
-                     <li><a class="page-scroll" href="/staticpages/Links/#study"><h3>Study</h3> <i>The word</i></a>
+                    <li><a href="/orders/new"><h3>Order</h3> <i>Bibles and books</i></a>
+                     <li><a href="/staticpages/Gospel/#gospel"> <h3>Share</h3><i>The Gospel </i></a>
+                     <li><a href="/staticpages/Links/#study"><h3>Study</h3> <i>The word</i></a>
                     </li>
                      <li>
-                        <a class="page-scroll" href="/#contact"> <h3>Contact</h3> <i>us</i> </a>
+                        <a href="/#contact"> <h3>Contact</h3> <i>us</i> </a>
                     </li>
                 </ul>
             </div>

--- a/app/views/staticpages/Books.html.erb
+++ b/app/views/staticpages/Books.html.erb
@@ -27,7 +27,7 @@
 
       </div>
       <div class="col-sm-6">
-        <a href="/staticpages/Books/#foundation"><img src="/img/basic_elements.jpg"style=width:40%;height:40%;padding-top:20px;padding-bottom:20px;></a>  <br><%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl page-scroll' %>
+        <a href="/staticpages/Books/#foundation"><img src="/img/basic_elements.jpg"style=width:40%;height:40%;padding-top:20px;padding-bottom:20px;></a>  <br><%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl' %>
       </div>
     </div>
   </div>
@@ -48,7 +48,7 @@
         <a href="http://mass.ministrybooks.org/en/download-books/" target="_blank">Download PDF version</a>
       </div>
       <div class="col-sm-6">
-        <a href= "http://www.ministrybooks.org/books.cfm?id=2DCAC9"><img src="/img/christian_experience.jpg"style=width:40%;height:40%;padding-top:20px;padding-bottom:20px;></a> <br><%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl page-scroll' %>
+        <a href= "http://www.ministrybooks.org/books.cfm?id=2DCAC9"><img src="/img/christian_experience.jpg"style=width:40%;height:40%;padding-top:20px;padding-bottom:20px;></a> <br><%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl' %>
       </div>
     </div>
   </div>
@@ -70,7 +70,7 @@
 
       </div>
       <div class="col-sm-6">
-        <a href="/new"><img src="/img/church_set.jpg"style=width:40%;height:40%;padding-top:20px;padding-bottom:20px;></a>  <br><%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl page-scroll' %>
+        <a href="/new"><img src="/img/church_set.jpg"style=width:40%;height:40%;padding-top:20px;padding-bottom:20px;></a>  <br><%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl' %>
         </div>
   <!--<div class="videowrapper">
   <iframe width="560" height="315" src="https://www.youtube.com/embed/vcqbm4KI7Kc?list=PLEB0E7D3F08AA4F91" frameborder="0" allowfullscreen></iframe>

--- a/app/views/staticpages/Links.html.erb
+++ b/app/views/staticpages/Links.html.erb
@@ -88,7 +88,7 @@
                                     <div class="col-sm-6 faq">
                                         <h2>New Testament Recovery Version</h2>
                                         <p>Want to understand the Bible in a deeper way? This free study Bible features extensive notes emphasizing the revelation of the truth, outlines of each book, cross-references, charts and maps, and more.<a href="/staticpages/Sample/#recovery"> Learn more....</a></p>
-                                        <%= link_to 'Order Now', new_order_path, class: 'btn btn-primary btn-xl page-scroll' %>
+                                        <%= link_to 'Order Now', new_order_path, class: 'btn btn-primary btn-xl' %>
                                         <br><br><a href="http://online.recoveryversion.org/" target="_blank" class="btn btn-default">Read Online Now</a>
                                     </div>
                                 </div>

--- a/app/views/staticpages/Sample.html.erb
+++ b/app/views/staticpages/Sample.html.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="col-lg-4"style=padding-top:40px>
         <img src="/img/rcv.jpg" alt="recovery version"><br><br>
-        <%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl page-scroll' %>
+        <%= link_to 'Order your Free copy', new_order_path, class: 'btn btn-primary btn-xl' %>
         <br><br><a href="https://online.recoveryversion.org/" target="_blank" class="btn btn-default">Read Online Now</a><br><br>
       </div>
     </div>


### PR DESCRIPTION
Clicking a anchor link (starts with #) having a page-scroll class triggers a scroll animation.
However, clicking a normal link having the page-scroll class raise an error.
The page-scroll class has been misused in many places which means it is not intuitive.

This commit removes page-scroll class and show a scroll animation to all anchor links.
(Currently there seems only one anchor link - 'Learn more about our freebooks' from the main page)