### PR TITLE
Avoid address fields being reset by the widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   # Travis supports these versions: http://rubies.travis-ci.org/
 
 addons:
-  firefox: 'latest'
+  firefox: '65.0'
 
 services:
   - postgresql
@@ -20,9 +20,9 @@ services:
 # If needed, use xvfb to setup fake monitor display so Firefox GUI can be used by specs:
 # http://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-GUI-(e.g.-a-Web-browser)
 before_install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.20.0-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v0.24.0-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/app/assets/javascripts/orders.js.coffee
+++ b/app/assets/javascripts/orders.js.coffee
@@ -15,6 +15,7 @@ $(document).ready ->
     fitTextArea(@)
 
     widget.on "result:select", (value, item)->
+      $(@.element).data("selected", value)
       $(".hidden-address.suburb").val(item.suburb || '')
       $(".hidden-address.city_town").val(item.city || '')
       $(".hidden-address.post_code").val(item.postcode || '')
@@ -27,8 +28,8 @@ $(document).ready ->
       fitTextArea(@.element)
 
     $(this).on "change", ->
-      clear_hidden_values()
-
+      if ($(this).data("selected") || '').trim() != $(this).val().trim()
+        clear_hidden_values()
 
   $("#tertiary_institution").hide() unless $(".tertiary-institution-toggle").attr('checked')
 

--- a/spec/features/admin/manage_customers_spec.rb
+++ b/spec/features/admin/manage_customers_spec.rb
@@ -23,6 +23,7 @@ feature 'Managing customers', js: true do
     fill_in "First Name", with: "John"
     fill_in "Last Name", with: "Doe"
     select_address("1 Short Street")
+    select 'Far North District', from: 'District'
     fill_in "Phone", with: "12345678"
     fill_in "Email", with: "email@test.com"
     select "Phone", from: "Method received"
@@ -43,6 +44,7 @@ feature 'Managing customers', js: true do
     fill_in "First Name", with: "John"
     fill_in "Last Name", with: "Doe"
     select_address("1 Short Street")
+    select 'Far North District', from: 'District'
     select_item
     check "This order has already been delivered."
     click_button "Save and add another"


### PR DESCRIPTION
Actually the partial address values were reset from our code when the address field is changed.
Probably this code is written to make sure to delete partial address values if the address is directly typed rather than selected from the autocomplete dropdown.

Now the widget seems to trigger the change event even though the address is selected from the autocomplete dropdown which makes the partial address field values deleted in all cases.

Now the partial address values will be saved to the database the same way as before.