### PR TITLE
Prepare Cloud66 deploy

### DIFF
--- a/.cloud66/dbseed.sh
+++ b/.cloud66/dbseed.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cd $STACK_PATH
-bundle exec rake db:create
-bundle exec rake db:migrate
-bundle exec rake db:seed

--- a/.cloud66/deploy_hooks.yml
+++ b/.cloud66/deploy_hooks.yml
@@ -1,8 +1,0 @@
-qa:
-  after_symlink: # Or use after_rails depending on your application
-    - source: /.cloud66/dbseed.sh
-      destination: /tmp/dbseed.sh
-      target: rails
-      execute: true
-      run_on: single_server
-      apply_during: build_only

--- a/config/database.yml
+++ b/config/database.yml
@@ -25,4 +25,4 @@ production:
   <<: *default
   database: bfnz_production
   username: bfnz
-  password: <%= ENV['BFNZ_DATABASE_PASSWORD'] %>
+  password: <%= ENV['POSTGRESQL_PASSWORD'] %>

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,3 +1,0 @@
-rails:
-  configuration:
-    ruby_version: 3.1.2


### PR DESCRIPTION
There are the changes made to fix the deployment to Cloud66.

* Use the Cloud66 default DB password env variable name
* Remove the custom cloud66 setting files (These might not be the cause, but they are the same as the default and worked without them, so included in the pull request. @SamuelGarratt hope that is ok.)