### PR TITLE
Reverts strscan to 3.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,4 +97,4 @@ group :test do
   gem 'webmock', '~> 3.18'
 end
 
-gem "strscan", '3.0.6'
+gem "strscan", '3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
-    strscan (3.0.6)
+    strscan (3.0.1)
     thor (1.2.2)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -338,7 +338,7 @@ DEPENDENCIES
   spreadsheet (~> 1.3)
   sprockets-rails
   stimulus-rails
-  strscan (= 3.0.6)
+  strscan (= 3.0.1)
   timecop (~> 0.9.6)
   turbo-rails
   tzinfo-data


### PR DESCRIPTION
`strscan` is a default gem so just going to leave it as is for now