### PR TITLE
fix-admin-new-customer-form

### DIFF
--- a/app/forms/admin/new_customer_form.rb
+++ b/app/forms/admin/new_customer_form.rb
@@ -7,11 +7,37 @@ module Admin
     validate :contains_at_least_one_item
 
     def order_attributes
-      attributes.stringify_keys.slice(*order_attr_keys)
+      {
+        item_ids: item_ids,
+        method_received: method_received,
+        method_of_discovery: method_of_discovery,
+        received_in_person: received_in_person
+      }
     end
 
     def customer_attributes
-      attributes.stringify_keys.slice(*customer_attr_keys)
+      {
+        'bad_address' => bad_address,
+        'title' => title,
+        'first_name' => first_name,
+        'last_name' => last_name,
+        'address' => address,
+        'suburb' => suburb,
+        'city_town' => city_town,
+        'post_code' => post_code,
+        'pxid' => pxid,
+        'dpid' => dpid,
+        'x' => x,
+        'y' => y,
+        'ta' => ta,
+        'bad_address' => bad_address,
+        'phone' => phone,
+        'email' => email,
+        'tertiary_student' => tertiary_student,
+        'tertiary_institution' => tertiary_institution,
+        'admin_notes' => admin_notes,
+        'further_contact_requested' => further_contact_requested.to_i
+      }
     end
 
     def item_ids=(item_ids)

--- a/app/helpers/admin/customers_helper.rb
+++ b/app/helpers/admin/customers_helper.rb
@@ -4,6 +4,7 @@ module Admin::CustomersHelper
   end
 
   def selected_further_contact_requested(customer_form)
-    contact_requested_options_for_select.assoc(customer_form.further_contact_requested.capitalize.tr("_", " ")).last
+    return contact_requested_options_for_select.assoc(customer_form.further_contact_requested.capitalize.tr("_", " ")).last if customer_form.present?
+    contact_requested_options_for_select
   end
 end


### PR DESCRIPTION
User Story 2975: Migrate virtus validations to activerecord models
===
[User Story 2975](https://dev.azure.com/biblesforamerica/BfNZ/_boards/board/t/BfNZ%20Team/Stories/?workitem=2975)

## Overview

The overview of this PR is to fix the admin new customer form broken issue


## What changed?

1. Updated the customer & order attributes accessing issue in admin/new_customer_form.rb
2. Updated the `selected_further_contact_requested` method in customers_helper.rb
