### PR TITLE
Add cors config to allow api requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem 'kaminari', '~> 1.2', '>= 1.2.2'
 gem 'attribute_normalizer', '~> 1.2'
 gem 'sassc-rails', '~> 2.1', '>= 2.1.2'
 gem 'strscan', '3.0.1'
+gem 'rack-cors'
 
 group :development, :test do
   gem 'pry', '~> 0.14.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8.1)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8.1)
@@ -329,6 +331,7 @@ DEPENDENCIES
   pg (~> 1.5)
   pry (~> 0.14.2)
   puma (~> 6.4)
+  rack-cors
   rails (~> 7.0.8)
   rails-controller-testing (~> 1.0, >= 1.0.5)
   rspec-rails (~> 6.1)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,21 @@
+# Be sure to restart your server when you modify this file.
+
+# Avoid CORS issues when API is called from the frontend app.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+
+# Read more: https://github.com/cyu/rack-cors
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'https://www.biblesfornewzealand.org.nz/',
+      'https://biblesfornewzealand.netlify.app/',
+      'https://bfnz-jekyll-staging.netlify.app/',
+      /.*bfnz-jekyll-staging.netlify.app$/,
+      /.*biblesfornewzealand.netlify.app$/,
+      ENV['ALLOWED_ORIGIN'] || 'http://localhost:4000' || 'http://localhost:3000'
+
+    resource '/api/v1/*',
+      headers: :any,
+      methods: [:get, :post, :put, :options]
+  end
+end


### PR DESCRIPTION
Set CORS to only allow access to our BfNZ - Jekyll site
===

[User Story 4797](https://dev.azure.com/biblesforamerica/BfNZ/_workitems/edit/4797)

## Overview

Setup cors config to allow API requests

## What changed?

1. Added gem `rack-cors`
2. Added `cors.rb` config file to initializers